### PR TITLE
Feature/hook up travis

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+example/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: node_js
+node_js:
+- '8'
+script:
+- npm run preflight
+
+deploy:
+  provider: npm
+  email: norm.maclennan@gmail.com
+  api_key: $NPM_API_KEY
+  on:
+    tags: true
+    branch: master
+    repo: Cimpress-MCP/ecs-publish

--- a/lib/acm-manager.js
+++ b/lib/acm-manager.js
@@ -65,11 +65,13 @@ module.exports.ensureCertificateIsIssued = function ({cfg}) {
         SubjectAlternativeNames: cfg.certificate.SubjectAlternativeNames,
         ValidationMethod: 'DNS'
       }).promise()
-        .then(async function (data) {
+        .then(function (data) {
           cfg.certificateArn = data.CertificateArn;
           logger.result(cfg.certificateArn);
           logger.action('Waiting a bit for AWS to generate validation records...');
-          await sleep(10000);
+          return sleep(10000);
+        })
+        .then(() => {
           logger.result('Proceeding.');
           return acm.describeCertificate({ CertificateArn: cfg.certificateArn }).promise();
         })

--- a/lib/ecs-manager.js
+++ b/lib/ecs-manager.js
@@ -233,12 +233,15 @@ module.exports.runStandaloneTask = function ({cfg}) {
     });
 };
 
-module.exports.verifyStandaloneTaskIsHealthy = async function ({cfg}) {
+module.exports.verifyStandaloneTaskIsHealthy = function ({cfg}) {
   logger.action('Waiting 30 seconds to ensure the test task stays up...');
-  await sleep(30000);
   const ecs = new ECS({ region: cfg.region });
   const svc = cfg.service;
-  return ecs.describeTasks({ cluster: svc.cluster, tasks: [ cfg.testTaskArn ] }).promise()
+
+  return sleep(30000)
+    .then(() => {
+      return ecs.describeTasks({ cluster: svc.cluster, tasks: [ cfg.testTaskArn ] }).promise();
+    })
     .then((data) => {
       if (data.tasks.length !== 1) throw new Error('Test task not found.');
       if (data.tasks[0].lastStatus !== 'RUNNING') throw new Error('Test task not running.');
@@ -252,10 +255,12 @@ module.exports.stopStandaloneTask = function ({cfg}) {
   const ecs = new ECS({ region: cfg.region });
   const svc = cfg.service;
   return ecs.stopTask({ cluster: svc.cluster, task: cfg.testTaskArn }).promise()
-    .then(async (data) => {
+    .then((data) => {
       logger.result('Stop command issued.');
       logger.action('Waiting 30 seconds to ensure the test task comes down...');
-      await sleep(30000);
+      return sleep(30000);
+    })
+    .then(() => {
       const ecs = new ECS({ region: cfg.region });
       return ecs.describeTasks({ cluster: cfg.service.cluster, tasks: [ cfg.testTaskArn ] }).promise();
     })

--- a/lib/elb-manager.js
+++ b/lib/elb-manager.js
@@ -54,7 +54,6 @@ function checkIfTargetGroupExists ({cfg}) {
 
 function checkIfTargetGoupIsInLoadBalancer ({cfg}) {
   logger.action(`Checking if target group is in load balancer...`);
-  const elb = new ELBv2({ region: cfg.region });
   return paginateListeners(cfg.region, { LoadBalancerArn: cfg.loadBalancerArn })
     .then((listeners) => {
       cfg.listeners = listeners;

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,12 +114,13 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.207.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.207.0.tgz",
-      "integrity": "sha1-wKMJd9jSeIMBhQsmX/Bet8n99/I=",
+      "version": "2.212.1",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.212.1.tgz",
+      "integrity": "sha1-gz2+jYN9RgWKN3Ksm7c7aRExNuQ=",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
+        "ieee754": "1.1.8",
         "jmespath": "0.15.0",
         "querystring": "0.2.0",
         "sax": "1.2.1",
@@ -265,6 +266,12 @@
         "ieee754": "1.1.8",
         "isarray": "1.0.0"
       }
+    },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+      "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -439,9 +446,9 @@
       "optional": true
     },
     "commander": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
-      "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg=="
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -450,11 +457,12 @@
       "dev": true
     },
     "concat-stream": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
-      "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
+        "buffer-from": "1.0.0",
         "inherits": "2.0.3",
         "readable-stream": "2.3.5",
         "typedarray": "0.0.6"
@@ -524,7 +532,7 @@
       "requires": {
         "globby": "5.0.0",
         "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1",
@@ -626,15 +634,15 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "4.18.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.18.2.tgz",
-      "integrity": "sha512-qy4i3wODqKMYfz9LUI8N2qYDkHkoieTbiHpMrYUI/WbjhXJQr7lI4VngixTgaG+yHX+NBCv7nW4hA0ShbvaNKw==",
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
       "dev": true,
       "requires": {
         "ajv": "5.5.2",
         "babel-code-frame": "6.26.0",
         "chalk": "2.3.2",
-        "concat-stream": "1.6.1",
+        "concat-stream": "1.6.2",
         "cross-spawn": "5.1.0",
         "debug": "3.1.0",
         "doctrine": "2.1.0",
@@ -662,6 +670,7 @@
         "path-is-inside": "1.0.2",
         "pluralize": "7.0.0",
         "progress": "2.0.0",
+        "regexpp": "1.0.1",
         "require-uncached": "1.0.3",
         "semver": "5.5.0",
         "strip-ansi": "4.0.0",
@@ -1230,9 +1239,9 @@
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
         "is-path-inside": "1.0.1"
@@ -1799,6 +1808,12 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.0.1.tgz",
+      "integrity": "sha512-8Ph721maXiOYSLtaDGKVmDn5wdsNaF6Px85qFNeMPQq0r8K5Y10tgP6YuR65Ws35n4DvzFcCxEnRNBIXQunzLw==",
       "dev": true
     },
     "require-directory": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "depcheck": "^0.6.9",
-    "eslint": "^4.18.2",
+    "eslint": "^4.19.1",
     "eslint-config-standard": "^11.0.0",
     "eslint-plugin-import": "^2.9.0",
     "eslint-plugin-node": "^6.0.1",
@@ -44,10 +44,10 @@
     "nsp": "^3.1.0"
   },
   "dependencies": {
-    "aws-sdk": "^2.207.0",
+    "aws-sdk": "^2.212.1",
     "chalk": "^2.3.2",
     "cmd-spawn": "^1.4.0",
-    "commander": "^2.15.0",
+    "commander": "^2.15.1",
     "envfile": "^2.3.0",
     "git-repo-info": "^1.4.1"
   }


### PR DESCRIPTION
This PR comprises a few very small changes that I didn't want to make individually. But I'm happy to pull out any changes we don't want if need be.

* Have eslint ignore `example/` - it's got jquery and a bunch of other junk generated by sphix that we don't care about linting.
* Revert async/await stuff in favor of promises. async/await was only introduced in node 7.something. Meanwhile node 6 is technically a "maintenance lts" until 2019, so I figure we should try to support it as much as possible.
  * Note that async/await would definitely help clean up the code a bit, but we can use something to transpile back to node6 compatible if we wanna go that route.
* Updated a few dependencies
* Hooked up a simple .travis.yml for building and deploying. API key is controlled in the repo settings on travis if we need to change it out - much easier that updating a bunch of files in a bunch of repos.